### PR TITLE
BEL-16530: Improve Onshape client detection. 

### DIFF
--- a/src/main/java/eu/bitwalker/useragentutils/Browser.java
+++ b/src/main/java/eu/bitwalker/useragentutils/Browser.java
@@ -245,10 +245,8 @@ public enum Browser {
 	/*
 	 * Onshape client.
 	 */
-	ONSHAPE(                Manufacturer.ONSHAPE, null,            1, "Onshape", new String[] {"Onshape"}, null, BrowserType.APP, RenderingEngine.OTHER, "Onshape\\/(([\\d]+)\\.([\\d]+).([\\d]+))"),
-		ONSHAPE_IPAD( 	Manufacturer.ONSHAPE, Browser.ONSHAPE, 2, "iPad",    new String[] {"iPad"},    null, BrowserType.APP, RenderingEngine.OTHER, "iPad"),
-		ONSHAPE_IPHONE(	Manufacturer.ONSHAPE, Browser.ONSHAPE, 3, "iPhone",  new String[] {"iPhone"},  null, BrowserType.APP, RenderingEngine.OTHER, "iPhone"),
-		ONSHAPE_ANDROID(Manufacturer.ONSHAPE, Browser.ONSHAPE, 4, "Android", new String[] {"Android"}, null, BrowserType.APP, RenderingEngine.OTHER, "Linux"),
+	ONSHAPE(        Manufacturer.ONSHAPE, null,            1, "Onshape",   new String[] {"Onshape"},   null, BrowserType.APP, RenderingEngine.OTHER, "Onshape\\/(([0-9]+)\\.?([\\w]+)?(\\.[\\w]+)?(\\.[\\w]+)?)"),
+		ONSHAPE1( 	Manufacturer.ONSHAPE, Browser.ONSHAPE, 2, "Onshape 1", new String[] {"Onshape/1"}, null, BrowserType.APP, RenderingEngine.OTHER, null),
 
 	SEAMONKEY(		Manufacturer.OTHER, null, 15, "SeaMonkey", new String[]{"SeaMonkey"}, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, "SeaMonkey\\/(([0-9]+)\\.?([\\w]+)?(\\.[\\w]+)?)"), // using Gecko Engine
 	

--- a/src/main/java/eu/bitwalker/useragentutils/Browser.java
+++ b/src/main/java/eu/bitwalker/useragentutils/Browser.java
@@ -242,6 +242,14 @@ public enum Browser {
 		THUNDERBIRD3(  	Manufacturer.MOZILLA, Browser.THUNDERBIRD, 130, "Thunderbird 3", new String[] { "Thunderbird/3" }, null, BrowserType.EMAIL_CLIENT, RenderingEngine.GECKO, null ),  // using Gecko Engine
 		THUNDERBIRD2(  	Manufacturer.MOZILLA, Browser.THUNDERBIRD, 120, "Thunderbird 2", new String[] { "Thunderbird/2" }, null, BrowserType.EMAIL_CLIENT, RenderingEngine.GECKO, null ),  // using Gecko Engine	
 		
+	/*
+	 * Onshape client.
+	 */
+	ONSHAPE(                Manufacturer.ONSHAPE, null,            1, "Onshape", new String[] {"Onshape"}, null, BrowserType.APP, RenderingEngine.OTHER, "Onshape\\/(([\\d]+)\\.([\\d]+).([\\d]+))"),
+		ONSHAPE_IPAD( 	Manufacturer.ONSHAPE, Browser.ONSHAPE, 2, "iPad",    new String[] {"iPad"},    null, BrowserType.APP, RenderingEngine.OTHER, "iPad"),
+		ONSHAPE_IPHONE(	Manufacturer.ONSHAPE, Browser.ONSHAPE, 3, "iPhone",  new String[] {"iPhone"},  null, BrowserType.APP, RenderingEngine.OTHER, "iPhone"),
+		ONSHAPE_ANDROID(Manufacturer.ONSHAPE, Browser.ONSHAPE, 4, "Android", new String[] {"Android"}, null, BrowserType.APP, RenderingEngine.OTHER, "Linux"),
+
 	SEAMONKEY(		Manufacturer.OTHER, null, 15, "SeaMonkey", new String[]{"SeaMonkey"}, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, "SeaMonkey\\/(([0-9]+)\\.?([\\w]+)?(\\.[\\w]+)?)"), // using Gecko Engine
 	
 	BOT(			Manufacturer.OTHER, null,12, "Robot/Spider", new String[] {"Googlebot", "Web Preview", "bot", "spider", "crawler", "Feedfetcher", "Slurp", "Twiceler", "Nutch", "BecomeBot"}, null, BrowserType.ROBOT, RenderingEngine.OTHER, null),

--- a/src/main/java/eu/bitwalker/useragentutils/Manufacturer.java
+++ b/src/main/java/eu/bitwalker/useragentutils/Manufacturer.java
@@ -132,7 +132,11 @@ public enum Manufacturer {
 	/**
 	 * Adobe Systems Inc.
 	 */
-	ADOBE(23, "Adobe Systems Inc.");
+	ADOBE(23, "Adobe Systems Inc."),
+	/**
+	 * Onshape, Inc.
+	 */
+	ONSHAPE(25, "Onshape, Inc.");
 	
 	
 	private final short id;

--- a/src/main/java/eu/bitwalker/useragentutils/Manufacturer.java
+++ b/src/main/java/eu/bitwalker/useragentutils/Manufacturer.java
@@ -136,7 +136,7 @@ public enum Manufacturer {
 	/**
 	 * Onshape, Inc.
 	 */
-	ONSHAPE(25, "Onshape, Inc.");
+	ONSHAPE(45, "Onshape, Inc.");
 	
 	
 	private final short id;

--- a/src/main/java/eu/bitwalker/useragentutils/OperatingSystem.java
+++ b/src/main/java/eu/bitwalker/useragentutils/OperatingSystem.java
@@ -99,16 +99,16 @@ public enum OperatingSystem {
 	 * iOS4, with the release of the iPhone 4, Apple renamed the OS to iOS.
 	 */	
 	IOS(			Manufacturer.APPLE,null, 2, "iOS", new String[] { "iOS", "iPhone OS", "like Mac OS X" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
-		iOS8_1_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 46, "iOS 8.1 (iPhone)", new String[] { "iPhone OS 8_1" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
-		iOS8_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 45, "iOS 8 (iPhone)", new String[] { "iPhone OS 8_0" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
-		iOS7_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 44, "iOS 7 (iPhone)", new String[] { "iPhone OS 7" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
+		iOS8_1_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 46, "iOS 8.1 (iPhone)", new String[] { "iPhone OS 8_1", "iPhone; iOS 8.1." },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
+		iOS8_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 45, "iOS 8 (iPhone)", new String[] { "iPhone OS 8_0", "iPhone; iOS 8.0." },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
+ 		iOS7_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 44, "iOS 7 (iPhone)", new String[] { "iPhone OS 7", "iPhone; iOS 7." },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
 		iOS6_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 43, "iOS 6 (iPhone)", new String[] { "iPhone OS 6" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
 		iOS5_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 42, "iOS 5 (iPhone)", new String[] { "iPhone OS 5" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
 		iOS4_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 41, "iOS 4 (iPhone)", new String[] { "iPhone OS 4" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
 		MAC_OS_X_IPAD(	Manufacturer.APPLE, OperatingSystem.IOS, 50, "Mac OS X (iPad)", new String[] { "iPad" },  null, DeviceType.TABLET, null ), // before Mac OS X
-		iOS8_1_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 54, "iOS 8.1 (iPad)", new String[] { "OS 8_1" },  null, DeviceType.TABLET, null ), // before Mac OS X
-		iOS8_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 53, "iOS 8 (iPad)", new String[] { "OS 8_0" },  null, DeviceType.TABLET, null ), // before Mac OS X
-		iOS7_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 52, "iOS 7 (iPad)", new String[] { "OS 7" },  null, DeviceType.TABLET, null ), // before Mac OS X
+		iOS8_1_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 54, "iOS 8.1 (iPad)", new String[] { "OS 8_1", "iPad; iOS 8.1." },  null, DeviceType.TABLET, null ), // before Mac OS X
+		iOS8_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 53, "iOS 8 (iPad)", new String[] { "OS 8_0", "iPad; iOS 8.0." },  null, DeviceType.TABLET, null ), // before Mac OS X
+		iOS7_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 52, "iOS 7 (iPad)", new String[] { "OS 7", "iPad; iOS 7." },  null, DeviceType.TABLET, null ), // before Mac OS X
 		iOS6_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 51, "iOS 6 (iPad)", new String[] { "OS 6" },  null, DeviceType.TABLET, null ), // before Mac OS X
 		MAC_OS_X_IPHONE(Manufacturer.APPLE, OperatingSystem.IOS, 40, "Mac OS X (iPhone)", new String[] { "iPhone" },  null, DeviceType.MOBILE, null ), // before Mac OS X
 		MAC_OS_X_IPOD(	Manufacturer.APPLE, OperatingSystem.IOS, 30, "Mac OS X (iPod)", new String[] { "iPod" },  null, DeviceType.MOBILE, null ), // before Mac OS X

--- a/src/main/java/eu/bitwalker/useragentutils/OperatingSystem.java
+++ b/src/main/java/eu/bitwalker/useragentutils/OperatingSystem.java
@@ -98,7 +98,7 @@ public enum OperatingSystem {
 	/**
 	 * iOS4, with the release of the iPhone 4, Apple renamed the OS to iOS.
 	 */	
-	IOS(			Manufacturer.APPLE,null, 2, "iOS", new String[] { "iPhone OS", "like Mac OS X" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
+	IOS(			Manufacturer.APPLE,null, 2, "iOS", new String[] { "iOS", "iPhone OS", "like Mac OS X" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
 		iOS8_1_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 46, "iOS 8.1 (iPhone)", new String[] { "iPhone OS 8_1" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
 		iOS8_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 45, "iOS 8 (iPhone)", new String[] { "iPhone OS 8_0" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
 		iOS7_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 44, "iOS 7 (iPhone)", new String[] { "iPhone OS 7" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions

--- a/src/test/java/eu/bitwalker/useragentutils/BrowserTest.java
+++ b/src/test/java/eu/bitwalker/useragentutils/BrowserTest.java
@@ -472,15 +472,18 @@ public class BrowserTest {
 	};
 	
 	String[] onshapeIPad = {
-			"Onshape/1.13.8 (iPad; iOS 8.1.2; Scale/2.00)"
+			"Onshape/1.13.8 (iPad; iOS 8.1.2; Scale/2.00)",
+			"Onshape/1.16 (iPad; iOS 8.1.2; Scale/2.00)"
 	};
 
 	String[] onshapeIPhone = {
-			"Onshape/1.13.8 (iPhone; iOS 8.1.2; Scale/3.00)"
+			"Onshape/1.13.8 (iPhone; iOS 8.1.2; Scale/3.00)",
+			"Onshape/1.16 (iPhone; iOS 8.1.2; Scale/3.00)"
 	};
 
 	String[] onshapeAndroid = {
-			"Onshape/1.13.8 (Linux; Android 5.0.1; nvidia SHIELD Tablet)"
+			"Onshape/1.13.8 (Linux; Android 5.0.1; nvidia SHIELD Tablet)",
+			"Onshape/1.16 (Linux; Android 5.0.1; nvidia SHIELD Tablet)"
 	};
 
 	String[] silk = {
@@ -649,9 +652,9 @@ public class BrowserTest {
 		testAgents(proxy, Browser.DOWNLOAD);
 		testAgents(thunderbird3, Browser.THUNDERBIRD3);
 		testAgents(thunderbird2, Browser.THUNDERBIRD2);
-                testAgents(onshapeIPad, Browser.ONSHAPE_IPAD);
-                testAgents(onshapeIPhone, Browser.ONSHAPE_IPHONE);
-                testAgents(onshapeAndroid, Browser.ONSHAPE_ANDROID);
+                testAgents(onshapeIPad, Browser.ONSHAPE1);
+                testAgents(onshapeIPhone, Browser.ONSHAPE1);
+                testAgents(onshapeAndroid, Browser.ONSHAPE1);
 		testAgents(silk, Browser.SILK);
 		testAgents(iTunes, Browser.APPLE_ITUNES);
 		testAgents(appStore, Browser.APPLE_APPSTORE);

--- a/src/test/java/eu/bitwalker/useragentutils/BrowserTest.java
+++ b/src/test/java/eu/bitwalker/useragentutils/BrowserTest.java
@@ -471,6 +471,18 @@ public class BrowserTest {
 			"Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.17) Gecko/20080914 Thunderbird/2.0.0.17"
 	};
 	
+	String[] onshapeIPad = {
+			"Onshape/1.13.8 (iPad; iOS 8.1.2; Scale/2.00)"
+	};
+
+	String[] onshapeIPhone = {
+			"Onshape/1.13.8 (iPhone; iOS 8.1.2; Scale/3.00)"
+	};
+
+	String[] onshapeAndroid = {
+			"Onshape/1.13.8 (Linux; Android 5.0.1; nvidia SHIELD Tablet)"
+	};
+
 	String[] silk = {
 			"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us; Silk/1.1.0-80) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16 Silk-Accelerated=true"
 	};
@@ -637,6 +649,9 @@ public class BrowserTest {
 		testAgents(proxy, Browser.DOWNLOAD);
 		testAgents(thunderbird3, Browser.THUNDERBIRD3);
 		testAgents(thunderbird2, Browser.THUNDERBIRD2);
+                testAgents(onshapeIPad, Browser.ONSHAPE_IPAD);
+                testAgents(onshapeIPhone, Browser.ONSHAPE_IPHONE);
+                testAgents(onshapeAndroid, Browser.ONSHAPE_ANDROID);
 		testAgents(silk, Browser.SILK);
 		testAgents(iTunes, Browser.APPLE_ITUNES);
 		testAgents(appStore, Browser.APPLE_APPSTORE);

--- a/src/test/java/eu/bitwalker/useragentutils/OperatingSystemTest.java
+++ b/src/test/java/eu/bitwalker/useragentutils/OperatingSystemTest.java
@@ -367,6 +367,18 @@ public class OperatingSystemTest {
 			"Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.0.7) Gecko/2009021910 Firefox/3.0.7 (via ggpht.com)" // Gmail proxy server
 	};
 	
+	String[] onshapeIPad = {
+			"Onshape/1.13.8 (iPad; iOS 8.1.2; Scale/2.00)"
+	};
+
+	String[] onshapeIPhone = {
+			"Onshape/1.13.8 (iPhone; iOS 8.1.2; Scale/3.00)"
+	};
+
+	String[] onshapeAndroid = {
+			"Onshape/1.13.8 (Linux; Android 5.0.1; nvidia SHIELD Tablet)"
+	};
+
 	String[] unknown = {
 		null	
 	};
@@ -419,7 +431,7 @@ public class OperatingSystemTest {
 		testAgents(android1g, OperatingSystem.ANDROID1);
 		testAgents(android2g, OperatingSystem.ANDROID2);
 		testAgents(android4g, OperatingSystem.ANDROID4);
-        testAgents(android5g, OperatingSystem.ANDROID5);
+		testAgents(android5g, OperatingSystem.ANDROID5);
 		testAgents(android2_tablet, OperatingSystem.ANDROID2_TABLET);
 		testAgents(android3_tablet, OperatingSystem.ANDROID3_TABLET);
 		testAgents(android4_tablet, OperatingSystem.ANDROID4_TABLET);
@@ -435,6 +447,9 @@ public class OperatingSystemTest {
 		testAgents(proxy, OperatingSystem.PROXY);
 		testAgents(genericMobile, OperatingSystem.UNKNOWN_MOBILE);
 		testAgents(genericTablet, OperatingSystem.UNKNOWN_TABLET);
+		testAgents(onshapeIPad, OperatingSystem.iOS8_1_IPAD);
+		testAgents(onshapeIPhone, OperatingSystem.iOS8_1_IPHONE);
+		testAgents(onshapeAndroid, OperatingSystem.ANDROID5_TABLET);
 		testAgents(unknown, OperatingSystem.UNKNOWN);
 
 	}


### PR DESCRIPTION
Improve Onshape client detection. 
Back out Browser changes to be non-OS specific. 
That is now in the OperatingSystem detection. 
Add more tests.

Tested by hitting a local server with multiple desktop browsers, iOS 8 iPhone, iOS 7 and 8 iPad, Android Nexus.

@ksmith14 

This is my same change as before plus the changes listed above.
