### PR TITLE
Final Onshape updates

### DIFF
--- a/src/main/java/eu/bitwalker/useragentutils/Browser.java
+++ b/src/main/java/eu/bitwalker/useragentutils/Browser.java
@@ -274,10 +274,10 @@ public enum Browser {
 	/*
 	 * Onshape client.
 	 */
-	ONSHAPE(                Manufacturer.ONSHAPE, null,            1, "Onshape", new String[] {"Onshape"}, null, BrowserType.APP, RenderingEngine.OTHER, "Onshape\\/(([\\d]+)\\.([\\d]+).([\\d]+))"),
-		ONSHAPE_IPAD( 	Manufacturer.ONSHAPE, Browser.ONSHAPE, 2, "iPad",    new String[] {"iPad"},    null, BrowserType.APP, RenderingEngine.OTHER, "iPad"),
-		ONSHAPE_IPHONE(	Manufacturer.ONSHAPE, Browser.ONSHAPE, 3, "iPhone",  new String[] {"iPhone"},  null, BrowserType.APP, RenderingEngine.OTHER, "iPhone"),
-		ONSHAPE_ANDROID(Manufacturer.ONSHAPE, Browser.ONSHAPE, 4, "Android", new String[] {"Android"}, null, BrowserType.APP, RenderingEngine.OTHER, "Linux"),
+	ONSHAPE(                Manufacturer.ONSHAPE, null,            1, "Onshape", new String[] { "Onshape" }, null, BrowserType.APP, RenderingEngine.OTHER, "Onshape\\/(([\\d]+)\\.([\\d]+)(\\.[\\d]+)?)"),
+		ONSHAPE_IPAD( 	Manufacturer.ONSHAPE, Browser.ONSHAPE, 2, "Onshape iPad",    new String[] { "iPad" },    null, BrowserType.APP, RenderingEngine.OTHER, null),
+		ONSHAPE_IPHONE(	Manufacturer.ONSHAPE, Browser.ONSHAPE, 3, "Onshape iPhone",  new String[] { "iPhone" },  null, BrowserType.APP, RenderingEngine.OTHER, null),
+		ONSHAPE_ANDROID(Manufacturer.ONSHAPE, Browser.ONSHAPE, 4, "Onshape Android", new String[] { "Android" }, null, BrowserType.APP, RenderingEngine.OTHER, null),
 
 	SEAMONKEY(		Manufacturer.OTHER, null, 15, "SeaMonkey", new String[]{"SeaMonkey"}, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, "SeaMonkey\\/(([0-9]+)\\.?([\\w]+)?(\\.[\\w]+)?)"), // using Gecko Engine
 
@@ -373,7 +373,7 @@ public enum Browser {
 		Pattern pattern = this.getVersionRegEx();
 		if (userAgentString != null && pattern != null) {
 			Matcher matcher = pattern.matcher(userAgentString);
-			if (matcher.find()) {
+			if (matcher.find() && matcher.groupCount() > 1) {
 				String fullVersionString = matcher.group(1);
 				String majorVersion = matcher.group(2);
 				String minorVersion = "0";

--- a/src/main/java/eu/bitwalker/useragentutils/OperatingSystem.java
+++ b/src/main/java/eu/bitwalker/useragentutils/OperatingSystem.java
@@ -101,25 +101,25 @@ public enum OperatingSystem {
 	 * iOS4, with the release of the iPhone 4, Apple renamed the OS to iOS.
 	 */	
 	IOS(			Manufacturer.APPLE,null, 2, "iOS", new String[] { "iOS", "iPhone OS", "like Mac OS X" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
-		iOS9_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 90, "iOS 9 (iPhone)", new String[] { "iPhone OS 9" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
-		iOS8_4_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 49, "iOS 8.4 (iPhone)", new String[] { "iPhone OS 8_4" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
-		iOS8_3_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 48, "iOS 8.3 (iPhone)", new String[] { "iPhone OS 8_3" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
-		iOS8_2_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 47, "iOS 8.2 (iPhone)", new String[] { "iPhone OS 8_2" },  null, DeviceType.MOBILE, null ), // version that added Apple Watch support
-		iOS8_1_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 46, "iOS 8.1 (iPhone)", new String[] { "iPhone OS 8_1" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
-		iOS8_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 45, "iOS 8 (iPhone)", new String[] { "iPhone OS 8" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
-		iOS7_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 44, "iOS 7 (iPhone)", new String[] { "iPhone OS 7" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
-		iOS6_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 43, "iOS 6 (iPhone)", new String[] { "iPhone OS 6" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
-		iOS5_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 42, "iOS 5 (iPhone)", new String[] { "iPhone OS 5" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
-		iOS4_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 41, "iOS 4 (iPhone)", new String[] { "iPhone OS 4" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
+		iOS9_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 90, "iOS 9 (iPhone)", new String[] { "iPhone OS 9", "iPhone; iOS 9.0." },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
+		iOS8_4_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 49, "iOS 8.4 (iPhone)", new String[] { "iPhone OS 8_4", "iPhone; iOS 8.4." },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
+		iOS8_3_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 48, "iOS 8.3 (iPhone)", new String[] { "iPhone OS 8_3", "iPhone; iOS 8.3." },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
+		iOS8_2_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 47, "iOS 8.2 (iPhone)", new String[] { "iPhone OS 8_2", "iPhone; iOS 8.2." },  null, DeviceType.MOBILE, null ), // version that added Apple Watch support
+		iOS8_1_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 46, "iOS 8.1 (iPhone)", new String[] { "iPhone OS 8_1", "iPhone; iOS 8.1." },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
+		iOS8_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 45, "iOS 8 (iPhone)", new String[] { "iPhone OS 8", "iPhone; iOS 8.0." },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
+		iOS7_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 44, "iOS 7 (iPhone)", new String[] { "iPhone OS 7", "iPhone; iOS 7.0." },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
+		iOS6_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 43, "iOS 6 (iPhone)", new String[] { "iPhone OS 6", "iPhone; iOS 6.0." },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
+		iOS5_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 42, "iOS 5 (iPhone)", new String[] { "iPhone OS 5", "iPhone; iOS 5.0." },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
+		iOS4_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 41, "iOS 4 (iPhone)", new String[] { "iPhone OS 4", "iPhone; iOS 4.0." },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
 		MAC_OS_X_IPAD(	Manufacturer.APPLE, OperatingSystem.IOS, 50, "Mac OS X (iPad)", new String[] { "iPad" },  null, DeviceType.TABLET, null ), // before Mac OS X
 		iOS9_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 58, "iOS 9 (iPad)", new String[] { "OS 9" },  null, DeviceType.TABLET, null ), // before Mac OS X
-		iOS8_4_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 57, "iOS 8.4 (iPad)", new String[] { "OS 8_4" },  null, DeviceType.TABLET, null ), // before Mac OS X
-		iOS8_3_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 56, "iOS 8.3 (iPad)", new String[] { "OS 8_3" },  null, DeviceType.TABLET, null ), // before Mac OS X
-		iOS8_2_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 55, "iOS 8.2 (iPad)", new String[] { "OS 8_2" },  null, DeviceType.TABLET, null ), // before Mac OS X
-		iOS8_1_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 54, "iOS 8.1 (iPad)", new String[] { "OS 8_1" },  null, DeviceType.TABLET, null ), // before Mac OS X
-		iOS8_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 53, "iOS 8 (iPad)", new String[] { "OS 8_0" },  null, DeviceType.TABLET, null ), // before Mac OS X
-		iOS7_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 52, "iOS 7 (iPad)", new String[] { "OS 7" },  null, DeviceType.TABLET, null ), // before Mac OS X
-		iOS6_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 51, "iOS 6 (iPad)", new String[] { "OS 6" },  null, DeviceType.TABLET, null ), // before Mac OS X
+		iOS8_4_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 57, "iOS 8.4 (iPad)", new String[] { "OS 8_4", "iPad; iOS 8.4." },  null, DeviceType.TABLET, null ), // before Mac OS X
+		iOS8_3_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 56, "iOS 8.3 (iPad)", new String[] { "OS 8_3", "iPad; iOS 8.3." },  null, DeviceType.TABLET, null ), // before Mac OS X
+		iOS8_2_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 55, "iOS 8.2 (iPad)", new String[] { "OS 8_2", "iPad; iOS 8.2." },  null, DeviceType.TABLET, null ), // before Mac OS X
+		iOS8_1_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 54, "iOS 8.1 (iPad)", new String[] { "OS 8_1", "iPad; iOS 8.1." },  null, DeviceType.TABLET, null ), // before Mac OS X
+		iOS8_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 53, "iOS 8 (iPad)", new String[] { "OS 8_0", "iPad; iOS 8.0." },  null, DeviceType.TABLET, null ), // before Mac OS X
+		iOS7_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 52, "iOS 7 (iPad)", new String[] { "OS 7", "iPad; iOS 7.0." },  null, DeviceType.TABLET, null ), // before Mac OS X
+		iOS6_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 51, "iOS 6 (iPad)", new String[] { "OS 6", "iPad; iOS 6.0." },  null, DeviceType.TABLET, null ), // before Mac OS X
 		MAC_OS_X_IPHONE(Manufacturer.APPLE, OperatingSystem.IOS, 40, "Mac OS X (iPhone)", new String[] { "iPhone" },  null, DeviceType.MOBILE, null ), // before Mac OS X
 		MAC_OS_X_IPOD(	Manufacturer.APPLE, OperatingSystem.IOS, 30, "Mac OS X (iPod)", new String[] { "iPod" },  null, DeviceType.MOBILE, null ), // before Mac OS X
 	

--- a/src/test/java/eu/bitwalker/useragentutils/BrowserTest.java
+++ b/src/test/java/eu/bitwalker/useragentutils/BrowserTest.java
@@ -516,11 +516,14 @@ public class BrowserTest {
 	};
 
 	String[] onshapeIPhone = {
-			"Onshape/1.13.8 (iPhone; iOS 8.1.2; Scale/3.00)"
+			"Onshape/1.13.8 (iPhone; iOS 8.1.2; Scale/3.00)",
+			"Onshape/1.36.6567 (iPhone; iOS 9.0.2; Scale/2.00)"
 	};
 
 	String[] onshapeAndroid = {
-			"Onshape/1.13.8 (Linux; Android 5.0.1; nvidia SHIELD Tablet)"
+			"Onshape/1.13.8 (Linux; Android 5.0.1; nvidia SHIELD Tablet)",
+			"Onshape/1.37.3671 (NVIDIA | SHIELD Tablet; Android 5.1.1)",
+			"Onshape/1.37.3671 (htc | Nexus 9; Android 5.1.1)"
 	};
 
 	String[] silk = {
@@ -604,7 +607,9 @@ public class BrowserTest {
         testVersions("Mozilla/5.0 (iPad; CPU OS 7_0_3 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Coast/1.1.3.65998 Mobile/11B511 Safari/7534.48.3", new Version("1.1.3.65998", "1", "1"));
         testVersions("Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36 OPR/23.0.1522.60", new Version("23.0.1522.60", "23", "0"));
         testVersions("Mozilla/5.0 (Linux; Android 4.1.2; HTC One SV Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.81 Mobile Safari/537.36 OPR/28.0.1764.90386", new Version("28.0.1764.90386", "28", "0"));
-
+		testVersions("Onshape/1.36.6567 (iPhone; iOS 9.0.2; Scale/2.00)", new Version("1.36.6567", "1", "36"));
+		testVersions("Onshape/1.37.3671 (NVIDIA | SHIELD Tablet; Android 5.1.1)", new Version("1.37.3671", "1", "37"));
+		testVersions("Onshape/1.37 (NVIDIA | SHIELD Tablet; Android 5.1.1)", new Version("1.37", "1", "37"));
 	}
 
 	private void testVersions(String ua, Version expectedVersion) {
@@ -705,9 +710,9 @@ public class BrowserTest {
 		testAgents(proxy, Browser.DOWNLOAD);
 		testAgents(thunderbird3, Browser.THUNDERBIRD3);
 		testAgents(thunderbird2, Browser.THUNDERBIRD2);
-                testAgents(onshapeIPad, Browser.ONSHAPE_IPAD);
-                testAgents(onshapeIPhone, Browser.ONSHAPE_IPHONE);
-                testAgents(onshapeAndroid, Browser.ONSHAPE_ANDROID);
+		testAgents(onshapeIPad, Browser.ONSHAPE_IPAD);
+		testAgents(onshapeIPhone, Browser.ONSHAPE_IPHONE);
+		testAgents(onshapeAndroid, Browser.ONSHAPE_ANDROID);
 		testAgents(silk, Browser.SILK);
 		testAgents(iTunes, Browser.APPLE_ITUNES);
 		testAgents(appStore, Browser.APPLE_APPSTORE);

--- a/src/test/java/eu/bitwalker/useragentutils/OperatingSystemTest.java
+++ b/src/test/java/eu/bitwalker/useragentutils/OperatingSystemTest.java
@@ -182,8 +182,13 @@ public class OperatingSystemTest {
 	{
 			"Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/538.34.9 (KHTML, like Gecko) Mobile/12A4265u"
 	};
-	
-	String[] iPhone8_1 = 
+
+	String[] iPhone9 =
+	{
+			"Onshape/1.36.6567 (iPhone; iOS 9.0.2; Scale/2.00)"
+	};
+
+	String[] iPhone8_1 =
 	{
 			"Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B401 Safari/600.1.4"
 	};
@@ -436,6 +441,7 @@ public class OperatingSystemTest {
 		testAgents(iPhone8, OperatingSystem.iOS8_IPHONE);
 		testAgents(iPhone8_1, OperatingSystem.iOS8_1_IPHONE);
 		testAgents(iPhone8_3, OperatingSystem.iOS8_3_IPHONE);
+		testAgents(iPhone9, OperatingSystem.iOS9_IPHONE);
 		testAgents(iPods, OperatingSystem.MAC_OS_X_IPOD);
 		testAgents(iPadIos6, OperatingSystem.iOS6_IPAD);
 		testAgents(iPadIos7, OperatingSystem.iOS7_IPAD);


### PR DESCRIPTION
I restructured this repo. "trunk" is now the clean fork of user-agent-utils. "onshape-trunk" is the base for our changes. 

Most of the updates here are to handle the new device name format (and order) that our Android and iOS apps are reporting in the user-agent header.
